### PR TITLE
Add pcscd into mirakurun container

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ docker-tv-recorder
 ## Requirements
 - docker
 - direnv
-- pcscd (Mirakurun)
 
 ## Usage
 
@@ -25,7 +24,11 @@ docker-compose up -d
 
 - `.envrc` の `DOCKER_HOST` の値には `tcp://${DOCKER_HOST_IP}:2375` を指定します。
   - `docker-compose` を実行するマシンと同一であれば不要です。
-- host に B-CAS カードが挿入されたカードリーダーが接続されていて、 pcscd によって認識されている必要があります。
+- ホストにチューナーを接続しドライバーをインストールしておく必要があります。
+  - [PX-S1UD](http://www.plex-net.co.jp/product/px-s1udv2/) で動作確認しています。
+- ホストに B-CAS カードを挿入したカードリーダーが接続されている必要があります。
+  - カードリーダーによっては別途ドライバーのインストールが必要です。
+  - ホストに pcscd は不要になりました。起動している場合は競合するため停止してください。
 
 ```
 docker-compose build

--- a/mirakurun/Dockerfile
+++ b/mirakurun/Dockerfile
@@ -3,14 +3,14 @@ FROM node:12-buster AS build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install libpcsclite-dev \
+    && apt-get -y --no-install-recommends install cmake libpcsclite-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://github.com/stz2012/libarib25/archive/09770e3.tar.gz | tar zxv \
-    && cd libarib25-09770e334837f6c67268c41c1c15784373d35e5b \
-    && make \
+RUN curl -sL https://github.com/stz2012/libarib25/archive/5b24f2f.tar.gz | tar zxv \
+    && cd libarib25-* \
+    && cmake . && make \
     && make install \
-    && rm -rf libarib25-09770e334837f6c67268c41c1c15784373d35e5b
+    && rm -rf libarib25-*
 
 WORKDIR /usr/local/src
 RUN curl -sL http://www13.plala.or.jp/sat/recdvb/recdvb-1.3.2.tgz | tar zxv \
@@ -30,7 +30,7 @@ WORKDIR /usr/local/lib/node_modules/mirakurun
 ENV DOCKER=YES
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install libpcsclite-dev tzdata \
+    && apt-get -y --no-install-recommends install pcscd libpcsclite-dev tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /usr/local/lib/libarib25.so.0.2.5 /usr/local/lib/
@@ -40,6 +40,7 @@ COPY --from=build /usr/local/bin/b25 /usr/local/bin/
 COPY --from=build /usr/local/bin/recdvb* /usr/local/bin/
 COPY --from=build /usr/local/lib/node_modules/mirakurun /usr/local/lib/node_modules/mirakurun
 COPY config/ /usr/local/etc/mirakurun/
+COPY services.sh /usr/local/bin/
 
-CMD [ "npm", "start" ]
+CMD [ "/usr/local/bin/services.sh" ]
 EXPOSE 40772 41772

--- a/mirakurun/docker-compose.yml
+++ b/mirakurun/docker-compose.yml
@@ -12,11 +12,13 @@ services:
     environment:
       TZ: Asia/Tokyo
     volumes:
-      - /var/run/pcscd/pcscd.comm:/var/run/pcscd/pcscd.comm
       - mirakurun_db:/usr/local/var/db/mirakurun
       - log:/usr/local/var/log
+    tmpfs:
+      - /run
     devices:
       - /dev/dvb:/dev/dvb
+      - /dev/bus/usb:/dev/bus/usb
     restart: always
     cap_add:
       - SYS_ADMIN

--- a/mirakurun/services.sh
+++ b/mirakurun/services.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -Ceu
+
+pcscd -f --error &
+npm start


### PR DESCRIPTION
## 背景
docker volume でマウントした `/var/run/pcscd/pcscd.comm` 経由での B-CAS の取り扱いが不安定で recdvb で init failed エラーが発生する。

## 対応内容
- container 内で pcscd を稼働させる修正
- libarib25 を最新に更新
