### PR TITLE
chore: update mirakurun image 3.8.0

### DIFF
--- a/chinachu/sample.envrc
+++ b/chinachu/sample.envrc
@@ -1,1 +1,1 @@
-DOCKER_HOST=tcp://host:2375
+export DOCKER_HOST=tcp://host:2375

--- a/mirakurun/README.md
+++ b/mirakurun/README.md
@@ -1,0 +1,29 @@
+# Mirakurun on Docker
+
+## Note
+
+Use [official one](https://github.com/Chinachu/Mirakurun/tree/master/docker) instead of this.
+
+## Usage
+
+### Launch / Update
+
+```
+docker compose down --rmi all
+docker compose pull
+docker compose up -d
+```
+
+### Copy config files
+
+```
+docker compose cp ./config/channels.yml mirakurun:/app-config/
+docker compose cp ./config/server.yml mirakurun:/app-config/
+docker compose cp ./config/tuners.yml mirakurun:/app-config/
+```
+
+Should be restart to apply configurations.
+
+```
+docker compose restart
+```

--- a/mirakurun/config/tuners.yml
+++ b/mirakurun/config/tuners.yml
@@ -5,7 +5,7 @@
     - GR
   command: dvbv5-zap -a 0 -c ./config/dvbconf-for-isdb/conf/dvbv5_channels_isdbt.conf -r -P <channel>
   dvbDevicePath: /dev/dvb/adapter0/dvr0
-  decoder: arib-b1-stream-test
+  decoder: arib-b25-stream-test
   isDisabled: false
 
 - name: PX-S1UD-2
@@ -13,5 +13,5 @@
     - GR
   command: dvbv5-zap -a 1 -c ./config/dvbconf-for-isdb/conf/dvbv5_channels_isdbt.conf -r -P <channel>
   dvbDevicePath: /dev/dvb/adapter1/dvr0
-  decoder: arib-b1-stream-test
+  decoder: arib-b25-stream-test
   isDisabled: false

--- a/mirakurun/docker-compose.yml
+++ b/mirakurun/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   mirakurun:
     container_name: mirakurun
-    image: chinachu/mirakurun:3.3.1
+    image: chinachu/mirakurun:3.8.0
     cap_add:
       - SYS_ADMIN
       - SYS_NICE

--- a/mirakurun/docker-compose.yml
+++ b/mirakurun/docker-compose.yml
@@ -17,10 +17,18 @@ services:
       - /dev/bus:/dev/bus
       - /dev/dvb:/dev/dvb
     volumes:
-      - /usr/local/mirakurun/run/:/var/run/
-      - /usr/local/mirakurun/opt/:/opt/
-      - ./config/:/app-config/
-      - /usr/local/mirakurun/data/:/app-data/
+      - type: bind
+        source: /opt/mirakurun/run/
+        target: /var/run/
+      - type: bind
+        source: /opt/mirakurun/opt/
+        target: /opt/
+      - type: bind
+        source: /opt/mirakurun/config/
+        target: /app-config/
+      - type: bind
+        source: /opt/mirakurun/data/
+        target: /app-data/
     restart: always
     logging:
       driver: json-file

--- a/mirakurun/sample.envrc
+++ b/mirakurun/sample.envrc
@@ -1,1 +1,1 @@
-DOCKER_HOST=tcp://host:2375
+export DOCKER_HOST=tcp://host:2375


### PR DESCRIPTION
## Summary

Update container image `chinachu/mirakurun` 3.8.0.

## References
- https://github.com/Chinachu/Mirakurun/releases/tag/3.8.0
- [chinachu/mirakurun:3.8.0](https://hub.docker.com/layers/chinachu/mirakurun/3.8.0/images/sha256-9402965433054816944f3784b94aff46b8bbef41b9dd42f2cd16359e5bb92917?context=explore)